### PR TITLE
internal/wguser: use Windows token impersonation for device access

### DIFF
--- a/.builds/windows-wine.yml
+++ b/.builds/windows-wine.yml
@@ -1,0 +1,32 @@
+image: ubuntu/lts
+packages:
+  - wine-stable
+sources:
+  - https://github.com/WireGuard/wgctrl-go
+environment:
+  GO111MODULE: "on"
+  GOOS: "windows"
+tasks:
+  - install-wine: |
+      # Make wine happy by also installing 32-bit libraries.
+      sudo dpkg --add-architecture i386
+      sudo apt -y update
+      sudo apt -y install wine32
+  - install-go: |
+      wget -q https://dl.google.com/go/go1.12.5.linux-amd64.tar.gz
+      sudo tar -C /usr/local -xzf go1.12.5.linux-amd64.tar.gz
+      sudo ln -s /usr/local/go/bin/go /usr/bin/go
+  - build: |
+      go version
+      # Install tools for Linux, although we'll run them on the Windows code.
+      GOOS=linux go get golang.org/x/lint/golint
+      GOOS=linux go get honnef.co/go/tools/cmd/staticcheck
+      cd wgctrl-go/
+      diff -u <(echo -n) <(/usr/local/go/bin/gofmt -d -s .)
+      go vet ./...
+      /home/build/go/bin/staticcheck ./...
+      /home/build/go/bin/golint -set_exit_status ./...
+      # Test each necessary package under wine.
+      go test -c . && wine wgctrl.test.exe -test.v
+      go test -c ./wgtypes && wine wgtypes.test.exe -test.v
+      go test -c ./internal/wguser && wine wguser.test.exe -test.v

--- a/go.mod
+++ b/go.mod
@@ -9,5 +9,5 @@ require (
 	github.com/microsoft/go-winio v0.4.12
 	github.com/mikioh/ipaddr v0.0.0-20190404000644-d465c8ab6721
 	golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529
-	golang.org/x/sys v0.0.0-20190509141414-a5b02f93d862
+	golang.org/x/sys v0.0.0-20190514135907-3a4b5fb9f71f
 )

--- a/go.sum
+++ b/go.sum
@@ -18,4 +18,6 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190509141414-a5b02f93d862 h1:rM0ROo5vb9AdYJi1110yjWGMej9ITfKddS89P3Fkhug=
 golang.org/x/sys v0.0.0-20190509141414-a5b02f93d862/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190514135907-3a4b5fb9f71f h1:Xab8gg26GrI/x3RNdVhVkHHM1XLyGeRBEvz4Q5x4YW8=
+golang.org/x/sys v0.0.0-20190514135907-3a4b5fb9f71f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/wguser/client.go
+++ b/internal/wguser/client.go
@@ -1,6 +1,7 @@
 package wguser
 
 import (
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -91,4 +92,8 @@ func (c *Client) ConfigureDevice(name string, cfg wgtypes.Config) error {
 // deviceName infers a device name from an absolute file path with extension.
 func deviceName(sock string) string {
 	return strings.TrimSuffix(filepath.Base(sock), filepath.Ext(sock))
+}
+
+func panicf(format string, a ...interface{}) {
+	panic(fmt.Sprintf(format, a...))
 }

--- a/internal/wguser/client_test.go
+++ b/internal/wguser/client_test.go
@@ -74,7 +74,7 @@ func testClient(t *testing.T, res []byte) (*Client, func() []byte) {
 	l, err := net.Listen("unix", path)
 	if err != nil {
 		if runtime.GOOS == "windows" {
-			t.Skip("skipping, couldn't listen on UNIX socket on Windows: %v", err)
+			t.Skipf("skipping, couldn't listen on UNIX socket on Windows: %v", err)
 		}
 
 		t.Fatalf("failed to create socket: %v", err)

--- a/internal/wguser/client_test.go
+++ b/internal/wguser/client_test.go
@@ -1,7 +1,6 @@
 package wguser
 
 import (
-	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
@@ -145,7 +144,3 @@ func testClient(t *testing.T, res []byte) (*Client, func() []byte) {
 func durPtr(d time.Duration) *time.Duration { return &d }
 func keyPtr(k wgtypes.Key) *wgtypes.Key     { return &k }
 func intPtr(v int) *int                     { return &v }
-
-func panicf(format string, a ...interface{}) {
-	panic(fmt.Sprintf(format, a...))
-}

--- a/internal/wguser/client_test.go
+++ b/internal/wguser/client_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -60,6 +61,8 @@ func TestClientDevice(t *testing.T) {
 }
 
 func testClient(t *testing.T, res []byte) (*Client, func() []byte) {
+	t.Helper()
+
 	tmp, err := ioutil.TempDir(os.TempDir(), "wireguardcfg-test")
 	if err != nil {
 		t.Fatalf("failed to create temporary directory: %v", err)
@@ -70,6 +73,10 @@ func testClient(t *testing.T, res []byte) (*Client, func() []byte) {
 	path := filepath.Join(tmp, "testwg0.sock")
 	l, err := net.Listen("unix", path)
 	if err != nil {
+		if runtime.GOOS == "windows" {
+			t.Skip("skipping, couldn't listen on UNIX socket on Windows: %v", err)
+		}
+
 		t.Fatalf("failed to create socket: %v", err)
 	}
 

--- a/internal/wguser/conn_windows.go
+++ b/internal/wguser/conn_windows.go
@@ -3,8 +3,11 @@
 package wguser
 
 import (
+	"errors"
 	"net"
+	"runtime"
 	"strings"
+	"unsafe"
 
 	winio "github.com/microsoft/go-winio"
 	"golang.org/x/sys/windows"
@@ -17,7 +20,142 @@ const (
 )
 
 // dial is the default implementation of Client.dial.
-func dial(device string) (net.Conn, error) {
+func dial(device string) (c net.Conn, err error) {
+	// Thanks to @zx2c4 for the sample code that makes this possible:
+	// https://github.com/WireGuard/wgctrl-go/issues/36#issuecomment-491912143.
+	//
+	// See also:
+	// https://docs.microsoft.com/en-us/windows/desktop/secauthz/impersonation-tokens
+	// https://docs.microsoft.com/en-us/windows/desktop/api/securitybaseapi/nf-securitybaseapi-reverttoself
+	//
+	// All of these operations require a locked OS thread for the duration of
+	// this function. Once the pipe is opened successfully, RevertToSelf
+	// terminates the impersonation of a client application.
+	runtime.LockOSThread()
+	defer func() {
+		// If no other errors occurred, ensure any error here is not dropped.
+		if werr := windows.RevertToSelf(); err == nil && werr != nil {
+			err = werr
+		}
+
+		runtime.UnlockOSThread()
+	}()
+
+	privileges := windows.Tokenprivileges{
+		PrivilegeCount: 1,
+		Privileges: [1]windows.LUIDAndAttributes{
+			{
+				Attributes: windows.SE_PRIVILEGE_ENABLED,
+			},
+		},
+	}
+
+	err = windows.LookupPrivilegeValue(
+		nil,
+		windows.StringToUTF16Ptr("SeDebugPrivilege"),
+		&privileges.Privileges[0].Luid,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := windows.ImpersonateSelf(windows.SecurityImpersonation); err != nil {
+		return nil, err
+	}
+
+	thread, err := windows.GetCurrentThread()
+	if err != nil {
+		return nil, err
+	}
+	defer windows.CloseHandle(thread)
+
+	var threadToken windows.Token
+	err = windows.OpenThreadToken(
+		thread,
+		windows.TOKEN_ADJUST_PRIVILEGES,
+		false,
+		&threadToken,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer threadToken.Close()
+
+	err = windows.AdjustTokenPrivileges(
+		threadToken,
+		false,
+		&privileges,
+		uint32(unsafe.Sizeof(privileges)),
+		nil,
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	processes, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPPROCESS, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer windows.CloseHandle(processes)
+
+	processEntry := windows.ProcessEntry32{
+		Size: uint32(unsafe.Sizeof(windows.ProcessEntry32{})),
+	}
+	var pid uint32
+	for err = windows.Process32First(processes, &processEntry); err == nil; err = windows.Process32Next(processes, &processEntry) {
+		if strings.ToLower(windows.UTF16ToString(processEntry.ExeFile[:])) == "winlogon.exe" {
+			pid = processEntry.ProcessID
+			break
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	if pid == 0 {
+		return nil, errors.New("wguser: unable to find winlogon.exe process")
+	}
+
+	winlogonProcess, err := windows.OpenProcess(
+		windows.PROCESS_QUERY_INFORMATION,
+		false,
+		pid,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer windows.CloseHandle(winlogonProcess)
+
+	var winlogonToken windows.Token
+	err = windows.OpenProcessToken(
+		winlogonProcess,
+		windows.TOKEN_IMPERSONATE|windows.TOKEN_DUPLICATE,
+		&winlogonToken,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer winlogonToken.Close()
+
+	var duplicatedToken windows.Token
+	err = windows.DuplicateTokenEx(
+		winlogonToken,
+		0,
+		nil,
+		windows.SecurityImpersonation,
+		windows.TokenImpersonation,
+		&duplicatedToken,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer duplicatedToken.Close()
+
+	err = windows.SetThreadToken(nil, duplicatedToken)
+	if err != nil {
+		return nil, err
+	}
+
 	return winio.DialPipe(device, nil)
 }
 


### PR DESCRIPTION
Depends on https://go-review.googlesource.com/c/sys/+/176625.

Fixes #36.

A hacked up repo for proof:

```
matt@DESKTOP-2G8V6U5 C:\Users\matt\wgctrl-go\cmd\wgctrl>go run main.go
interface: wgwindows0
  public key: 40Har5v8ur2gCO9fgSpvJfDWwUZcIP3yv9PjAFzmi0E=
  private key: (hidden)
  listening port: 58869
```