### PR TITLE
internal/wglinux: gracefully degrade if kernel implementation not ava…

### DIFF
--- a/os_linux.go
+++ b/os_linux.go
@@ -10,19 +10,26 @@ import (
 
 // newClients configures wginternal.Clients for Linux systems.
 func newClients() ([]wginternal.Client, error) {
-	// Linux has an in-kernel WireGuard implementation.
-	nlc, err := wglinux.New()
+	var clients []wginternal.Client
+
+	// Linux has an in-kernel WireGuard implementation. Determine if it is
+	// available and make use of it if so.
+	kc, ok, err := wglinux.New()
 	if err != nil {
 		return nil, err
+	}
+	if ok {
+		clients = append(clients, kc)
 	}
 
 	// Although it isn't recommended to use userspace implementations on Linux,
 	// it can be used. We make use of it in integration tests as well.
-	cfgc, err := wguser.New()
+	uc, err := wguser.New()
 	if err != nil {
 		return nil, err
 	}
 
-	// Netlink devices seem to appear first in wg(8).
-	return []wginternal.Client{nlc, cfgc}, nil
+	// Kernel devices seem to appear first in wg(8).
+	clients = append(clients, uc)
+	return clients, nil
 }


### PR DESCRIPTION
…ilable

This is a bit friendlier. Before/after:

```
root@unifi:~# ./wgctrl
2019/05/15 17:05:33 failed to open wgctrl: netlink receive: no such file or directory
```
```
root@unifi:~# ./wgctrl 
root@unifi:~# echo $?
0
```