### PR TITLE
 internal/wguser: match wg(8) Windows token impersonation behavior

### DIFF
--- a/.builds/windows-wine.yml
+++ b/.builds/windows-wine.yml
@@ -5,7 +5,6 @@ sources:
   - https://github.com/WireGuard/wgctrl-go
 environment:
   GO111MODULE: "on"
-  GOOS: "windows"
 tasks:
   - install-wine: |
       # Make wine happy by also installing 32-bit libraries.
@@ -22,11 +21,11 @@ tasks:
       GOOS=linux go get golang.org/x/lint/golint
       GOOS=linux go get honnef.co/go/tools/cmd/staticcheck
       cd wgctrl-go/
-      diff -u <(echo -n) <(/usr/local/go/bin/gofmt -d -s .)
-      go vet ./...
-      /home/build/go/bin/staticcheck ./...
-      /home/build/go/bin/golint -set_exit_status ./...
+      GOOS=windows diff -u <(echo -n) <(/usr/local/go/bin/gofmt -d -s .)
+      GOOS=windows go vet ./...
+      GOOS=windows /home/build/go/bin/staticcheck ./...
+      GOOS=windows /home/build/go/bin/golint -set_exit_status ./...
       # Test each necessary package under wine.
-      go test -c . && wine wgctrl.test.exe -test.v
-      go test -c ./wgtypes && wine wgtypes.test.exe -test.v
-      go test -c ./internal/wguser && wine wguser.test.exe -test.v
+      GOOS=windows go test -c . && wine wgctrl.test.exe -test.v
+      GOOS=windows go test -c ./wgtypes && wine wgtypes.test.exe -test.v
+      GOOS=windows go test -c ./internal/wguser && wine wguser.test.exe -test.v

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -63,7 +63,7 @@ func TestIntegrationClient(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Panic if a specific test takes too long.
-			timer := time.AfterFunc(20*time.Second, func() {
+			timer := time.AfterFunc(1*time.Minute, func() {
 				panic("test took too long")
 			})
 			defer timer.Stop()


### PR DESCRIPTION
See: https://git.zx2c4.com/WireGuard/tree/src/tools/wincompat/ipc.c.