### PR TITLE
Correct the winio import

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,11 @@ module golang.zx2c4.com/wireguard/wgctrl
 go 1.12
 
 require (
+	github.com/Microsoft/go-winio v0.4.12
 	github.com/google/go-cmp v0.3.0
 	github.com/jsimonetti/rtnetlink v0.0.0-20190606172950-9527aa82566a // indirect
 	github.com/mdlayher/genetlink v0.0.0-20190513144241-4cdc5dab577c
 	github.com/mdlayher/netlink v0.0.0-20190614145538-d8264f87dbe3
-	github.com/microsoft/go-winio v0.4.12
 	github.com/mikioh/ipaddr v0.0.0-20190404000644-d465c8ab6721
 	golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8
 	golang.org/x/net v0.0.0-20190613194153-d28f0bde5980 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Microsoft/go-winio v0.4.12 h1:xAfWHN1IrQ0NJ9TBC0KBZoqLjzDTr1ML+4MywiUOryc=
+github.com/Microsoft/go-winio v0.4.12/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -12,8 +14,6 @@ github.com/mdlayher/netlink v0.0.0-20190513144208-ba284d510044 h1:TpkQm/PKaI5boF
 github.com/mdlayher/netlink v0.0.0-20190513144208-ba284d510044/go.mod h1:gOrA34zDL0K3RsACQe54bDYLF/CeFspQ9m5DOycycQ8=
 github.com/mdlayher/netlink v0.0.0-20190614145538-d8264f87dbe3 h1:3IPcWjiboJFnnvHeXxT4pYw33BiPJn/DC5BKhcGEbGk=
 github.com/mdlayher/netlink v0.0.0-20190614145538-d8264f87dbe3/go.mod h1:ISujvOTprADlNr00kvJIu0d23q57wk2NSV/PT/TEk4E=
-github.com/microsoft/go-winio v0.4.12 h1:3vDRRsUnj2dKE7QKoedntu9hbuD8gzaVd2E2UZioqx4=
-github.com/microsoft/go-winio v0.4.12/go.mod h1:kcIxxtKZE55DEncT/EOvFiygPobhUWpSDqDb47poQOU=
 github.com/mikioh/ipaddr v0.0.0-20190404000644-d465c8ab6721 h1:RlZweED6sbSArvlE924+mUcZuXKLBHA35U7LN621Bws=
 github.com/mikioh/ipaddr v0.0.0-20190404000644-d465c8ab6721/go.mod h1:Ickgr2WtCLZ2MDGd4Gr0geeCH5HybhRJbonOgQpvSxc=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/internal/wguser/conn_windows.go
+++ b/internal/wguser/conn_windows.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"unsafe"
 
-	winio "github.com/microsoft/go-winio"
+	winio "github.com/Microsoft/go-winio"
 	"golang.org/x/sys/windows"
 )
 

--- a/internal/wguser/conn_windows_test.go
+++ b/internal/wguser/conn_windows_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	winio "github.com/microsoft/go-winio"
+	winio "github.com/Microsoft/go-winio"
 	"golang.org/x/sys/windows/registry"
 )
 


### PR DESCRIPTION
Currently go mod/go build is giving an error:
```
go: github.com/microsoft/go-winio@v0.4.14: parsing go.mod: unexpected module path "github.com/Microsoft/go-winio"
```