### PR TITLE
internal/wguser: use protected prefixes for windows pipe

### DIFF
--- a/internal/wguser/conn_windows.go
+++ b/internal/wguser/conn_windows.go
@@ -17,7 +17,7 @@ import (
 // Expected prefixes when dealing with named pipes.
 const (
 	pipePrefix = `\\.\pipe\`
-	wgPrefix   = `WireGuard\`
+	wgPrefix   = `ProtectedPrefix\Administrators\WireGuard\`
 )
 
 // dial is the default implementation of Client.dial.


### PR DESCRIPTION
This change will be in v0.0.24, so please don't merge it just yet.