### PR TITLE
internal/wguser: use x/sys/windows instead of syscall

### DIFF
--- a/internal/wguser/conn_windows.go
+++ b/internal/wguser/conn_windows.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"runtime"
 	"strings"
-	"syscall"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
@@ -195,7 +194,7 @@ func tryDial(device string, pid uint32, privileges windows.Tokenprivileges) (net
 		return nil, err
 	}
 
-	return winpipe.DialPipe(device, nil, (*syscall.SID)(localSystem))
+	return winpipe.DialPipe(device, nil, localSystem)
 }
 
 // find is the default implementation of Client.find.


### PR DESCRIPTION
[This commit](https://git.zx2c4.com/wireguard-go/commit/ipc/winpipe/pipe.go?id=01f8ef4e84a0354d33c32130f11c88d37d5f514d) in wireguard-go changed the import from `syscall` to `x/sys/windows`