### PR TITLE
internal/wguser: switch to use new winpipe functions

### DIFF
--- a/internal/wguser/conn_windows.go
+++ b/internal/wguser/conn_windows.go
@@ -194,7 +194,10 @@ func tryDial(device string, pid uint32, privileges windows.Tokenprivileges) (net
 		return nil, err
 	}
 
-	return winpipe.DialPipe(device, nil, localSystem)
+	pipeCfg := &winpipe.DialConfig{
+		ExpectedOwner: localSystem,
+	}
+	return winpipe.Dial(device, nil, pipeCfg)
 }
 
 // find is the default implementation of Client.find.

--- a/internal/wguser/conn_windows_test.go
+++ b/internal/wguser/conn_windows_test.go
@@ -53,7 +53,7 @@ func testListen(t *testing.T, device string) (l net.Listener, dir string, done f
 	// Attempt to create a unique name and avoid collisions.
 	dir = fmt.Sprintf(`wguser-test%d\`, time.Now().Nanosecond())
 
-	l, err := winpipe.ListenPipe(pipePrefix+dir+device, nil)
+	l, err := winpipe.Listen(pipePrefix+dir+device, nil)
 	if err != nil {
 		t.Fatalf("failed to create Windows named pipe: %v", err)
 	}


### PR DESCRIPTION
These functions were changed in:
https://git.zx2c4.com/wireguard-go/commit/?id=82f3e9e2afc1b52a88a691b1ce173623e525e4f0

I tried running the tests but I'm not sure how to fix the error:
> wguser: unable to find suitable winlogon.exe process to communicate with WireGuard
```
> go test -v ./...
=== RUN   TestClientClose
--- PASS: TestClientClose (0.00s)
=== RUN   TestClientDevices
--- PASS: TestClientDevices (0.00s)
=== RUN   TestClientDevice
=== RUN   TestClientDevice/first_error
=== RUN   TestClientDevice/not_found
=== RUN   TestClientDevice/first_not_found
=== RUN   TestClientDevice/first_ok
--- PASS: TestClientDevice (0.00s)
    --- PASS: TestClientDevice/first_error (0.00s)
    --- PASS: TestClientDevice/not_found (0.00s)
    --- PASS: TestClientDevice/first_not_found (0.00s)
    --- PASS: TestClientDevice/first_ok (0.00s)
=== RUN   TestClientConfigureDevice
=== RUN   TestClientConfigureDevice/first_error
=== RUN   TestClientConfigureDevice/not_found
=== RUN   TestClientConfigureDevice/first_not_found
=== RUN   TestClientConfigureDevice/first_ok
--- PASS: TestClientConfigureDevice (0.00s)
    --- PASS: TestClientConfigureDevice/first_error (0.00s)
    --- PASS: TestClientConfigureDevice/not_found (0.00s)
    --- PASS: TestClientConfigureDevice/first_not_found (0.00s)
    --- PASS: TestClientConfigureDevice/first_ok (0.00s)
=== RUN   TestIntegrationClient
=== RUN   TestIntegrationClient/get
=== RUN   TestIntegrationClient/configure
=== RUN   TestIntegrationClient/configure_many_IPs
=== RUN   TestIntegrationClient/configure_many_peers
=== RUN   TestIntegrationClient/configure_peers_update_only
=== RUN   TestIntegrationClient/reset
--- PASS: TestIntegrationClient (0.00s)
    --- PASS: TestIntegrationClient/get (0.00s)
    --- PASS: TestIntegrationClient/configure (0.00s)
    --- PASS: TestIntegrationClient/configure_many_IPs (0.00s)
    --- PASS: TestIntegrationClient/configure_many_peers (0.00s)
    --- PASS: TestIntegrationClient/configure_peers_update_only (0.00s)
    --- PASS: TestIntegrationClient/reset (0.00s)
=== RUN   TestIntegrationClientIsNotExist
--- PASS: TestIntegrationClientIsNotExist (0.00s)
PASS
ok      golang.zx2c4.com/wireguard/wgctrl       (cached)
?       golang.zx2c4.com/wireguard/wgctrl/cmd/wgctrl    [no test files]
?       golang.zx2c4.com/wireguard/wgctrl/internal/wginternal   [no test files]
?       golang.zx2c4.com/wireguard/wgctrl/internal/wglinux      [no test files]
?       golang.zx2c4.com/wireguard/wgctrl/internal/wglinux/internal/wgh [no test files]
?       golang.zx2c4.com/wireguard/wgctrl/internal/wgopenbsd    [no test files]
?       golang.zx2c4.com/wireguard/wgctrl/internal/wgopenbsd/internal/wgh       [no test files]
?       golang.zx2c4.com/wireguard/wgctrl/internal/wgtest       [no test files]
=== RUN   TestClientDevice
=== RUN   TestClientDevice/not_found
    client_test.go:43: userspace device: \\.\pipe\wguser-test235794700\wgtest0
=== RUN   TestClientDevice/ok
    client_test.go:43: userspace device: \\.\pipe\wguser-test238158500\wgtest0
    client_test.go:52: failed to get device: wguser: unable to find suitable winlogon.exe process to communicate with WireGuard
--- FAIL: TestClientDevice (0.01s)
    --- PASS: TestClientDevice/not_found (0.00s)
    --- FAIL: TestClientDevice/ok (0.01s)
=== RUN   TestClientConfigureDeviceError
=== RUN   TestClientConfigureDeviceError/not_found
    configure_test.go:64: userspace device: \\.\pipe\wguser-test249371500\wgtest0
=== RUN   TestClientConfigureDeviceError/bad_errno
    configure_test.go:64: userspace device: \\.\pipe\wguser-test251102100\wgtest0
--- PASS: TestClientConfigureDeviceError (0.01s)
    --- PASS: TestClientConfigureDeviceError/not_found (0.00s)
    --- PASS: TestClientConfigureDeviceError/bad_errno (0.01s)
=== RUN   TestClientConfigureDeviceOK
=== RUN   TestClientConfigureDeviceOK/ok,_none
    configure_test.go:147: userspace device: \\.\pipe\wguser-test262067600\wgtest0
    configure_test.go:150: failed to configure device: wguser: unable to find suitable winlogon.exe process to communicate with WireGuard
=== RUN   TestClientConfigureDeviceOK/ok,_clear_key
    configure_test.go:147: userspace device: \\.\pipe\wguser-test273691100\wgtest0
    configure_test.go:150: failed to configure device: wguser: unable to find suitable winlogon.exe process to communicate with WireGuard
=== RUN   TestClientConfigureDeviceOK/ok,_all
    configure_test.go:147: userspace device: \\.\pipe\wguser-test283957700\wgtest0
    configure_test.go:150: failed to configure device: wguser: unable to find suitable winlogon.exe process to communicate with WireGuard
--- FAIL: TestClientConfigureDeviceOK (0.03s)
    --- FAIL: TestClientConfigureDeviceOK/ok,_none (0.01s)
    --- FAIL: TestClientConfigureDeviceOK/ok,_clear_key (0.01s)
    --- FAIL: TestClientConfigureDeviceOK/ok,_all (0.01s)
=== RUN   TestClientDevices
=== RUN   TestClientDevices/invalid_key=value
    parse_test.go:156: userspace device: \\.\pipe\wguser-test294851200\wgtest0
=== RUN   TestClientDevices/invalid_public_key
    parse_test.go:156: userspace device: \\.\pipe\wguser-test306102600\wgtest0
=== RUN   TestClientDevices/short_public_key
    parse_test.go:156: userspace device: \\.\pipe\wguser-test316941900\wgtest0
=== RUN   TestClientDevices/invalid_fwmark
    parse_test.go:156: userspace device: \\.\pipe\wguser-test330824500\wgtest0
=== RUN   TestClientDevices/invalid_endpoint
    parse_test.go:156: userspace device: \\.\pipe\wguser-test342169600\wgtest0
=== RUN   TestClientDevices/invalid_allowed_ip
    parse_test.go:156: userspace device: \\.\pipe\wguser-test353069300\wgtest0
=== RUN   TestClientDevices/error
    parse_test.go:156: userspace device: \\.\pipe\wguser-test362733200\wgtest0
=== RUN   TestClientDevices/ok
    parse_test.go:156: userspace device: \\.\pipe\wguser-test372261000\wgtest0
    parse_test.go:162: failed to get devices: wguser: unable to find suitable winlogon.exe process to communicate with WireGuard
--- FAIL: TestClientDevices (0.09s)
    --- PASS: TestClientDevices/invalid_key=value (0.01s)
    --- PASS: TestClientDevices/invalid_public_key (0.01s)
    --- PASS: TestClientDevices/short_public_key (0.01s)
    --- PASS: TestClientDevices/invalid_fwmark (0.01s)
    --- PASS: TestClientDevices/invalid_endpoint (0.01s)
    --- PASS: TestClientDevices/invalid_allowed_ip (0.01s)
    --- PASS: TestClientDevices/error (0.01s)
    --- FAIL: TestClientDevices/ok (0.01s)
FAIL
FAIL    golang.zx2c4.com/wireguard/wgctrl/internal/wguser       0.231s
=== RUN   TestPreparedKeys
--- PASS: TestPreparedKeys (0.00s)
=== RUN   TestKeyExchange
--- PASS: TestKeyExchange (0.00s)
=== RUN   TestBadKeys
=== RUN   TestBadKeys/bad_base64
    types_test.go:100: OK error: wgtypes: failed to parse base64-encoded key: illegal base64 data at input byte 0
=== RUN   TestBadKeys/short_base64
    types_test.go:100: OK error: wgtypes: incorrect key size: 5
=== RUN   TestBadKeys/short_key
    types_test.go:100: OK error: wgtypes: incorrect key size: 3
=== RUN   TestBadKeys/long_base64
    types_test.go:100: OK error: wgtypes: incorrect key size: 40
=== RUN   TestBadKeys/long_bytes
    types_test.go:100: OK error: wgtypes: incorrect key size: 40
--- PASS: TestBadKeys (0.00s)
    --- PASS: TestBadKeys/bad_base64 (0.00s)
    --- PASS: TestBadKeys/short_base64 (0.00s)
    --- PASS: TestBadKeys/short_key (0.00s)
    --- PASS: TestBadKeys/long_base64 (0.00s)
    --- PASS: TestBadKeys/long_bytes (0.00s)
PASS
ok      golang.zx2c4.com/wireguard/wgctrl/wgtypes       0.144s
FAIL
```

I did try this code in our binary on Windows and it works.