### PR TITLE
internal/wgopenbsd: use SIOCGIFGMEMB const from golang.org/x/sys/unix

### DIFF
--- a/internal/wgopenbsd/client_openbsd.go
+++ b/internal/wgopenbsd/client_openbsd.go
@@ -344,7 +344,7 @@ func bePort(port uint16) int {
 // fd to retrieve members of an interface group.
 func ioctlIfgroupreq(fd int) func(*wgh.Ifgroupreq) error {
 	return func(ifg *wgh.Ifgroupreq) error {
-		return ioctl(fd, wgh.SIOCGIFGMEMB, unsafe.Pointer(ifg))
+		return ioctl(fd, unix.SIOCGIFGMEMB, unsafe.Pointer(ifg))
 	}
 }
 

--- a/internal/wgopenbsd/internal/wgh/defs.go
+++ b/internal/wgopenbsd/internal/wgh/defs.go
@@ -29,8 +29,6 @@ import "C"
 // Interface group types and constants.
 
 const (
-	SIOCGIFGMEMB = C.SIOCGIFGMEMB
-
 	SizeofIfgreq = C.sizeof_struct_ifg_req
 )
 

--- a/internal/wgopenbsd/internal/wgh/defs_openbsd_386.go
+++ b/internal/wgopenbsd/internal/wgh/defs_openbsd_386.go
@@ -7,8 +7,6 @@
 package wgh
 
 const (
-	SIOCGIFGMEMB = 0xc024698a
-
 	SizeofIfgreq = 0x10
 )
 

--- a/internal/wgopenbsd/internal/wgh/defs_openbsd_amd64.go
+++ b/internal/wgopenbsd/internal/wgh/defs_openbsd_amd64.go
@@ -7,8 +7,6 @@
 package wgh
 
 const (
-	SIOCGIFGMEMB = 0xc028698a
-
 	SizeofIfgreq = 0x10
 )
 

--- a/internal/wgopenbsd/internal/wgh/defs_openbsd_arm.go
+++ b/internal/wgopenbsd/internal/wgh/defs_openbsd_arm.go
@@ -7,8 +7,6 @@
 package wgh
 
 const (
-	SIOCGIFGMEMB = 0xc024698a
-
 	SizeofIfgreq = 0x10
 )
 

--- a/internal/wgopenbsd/internal/wgh/defs_openbsd_arm64.go
+++ b/internal/wgopenbsd/internal/wgh/defs_openbsd_arm64.go
@@ -7,8 +7,6 @@
 package wgh
 
 const (
-	SIOCGIFGMEMB = 0xc028698a
-
 	SizeofIfgreq = 0x10
 )
 


### PR DESCRIPTION
Use the constant already defined in package golang.org/x/sys/unix
instead of generating it in package internal/wgopenbsd/internal/wgh.