### PR TITLE
internal/windows: deadlock fix

### DIFF
--- a/internal/wgwindows/client_windows.go
+++ b/internal/wgwindows/client_windows.go
@@ -103,6 +103,9 @@ func (c *Client) interfaceHandle(name string) (handle windows.Handle, err error)
 		if err == nil {
 			break
 		}
+		if err == windows.ERROR_FILE_NOT_FOUND {
+			return 0, err
+		}
 	}
 	return
 }


### PR DESCRIPTION
Deadlock (infinite loop) happens when interfaceHandle() is called after the device was closed.
Ticket: https://github.com/WireGuard/wgctrl-go/issues/134

Issue explanation in code:
```
func issueTest() {
 devName := "your-device-name"

 client, _ := wgctrl.New()
 defer client.Close()

 client.Device(devName) // ok

 // TODO: disable (disconnect) WireGuard connection

 client.Device(devName) // BUG: deadlock in interfaceHandle() method !!!
}
```